### PR TITLE
Adding support for throwing an Error instead of just returning 'nothing'

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ capitalize("you shall not pass!"); // => "You shall not pass!"
 let div = (a, b) => a / b;
 
 // Throw exception instead of failing silently by passing an Error instance as 3rd param
-div = guard((a, b) => b > 0, div, new Error('Divide by 0!');
+div = guard((a, b) => b !== 0, div, new Error('Divide by 0!');
 
 div(8, 2); // => 4
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Usage
 var guard = require('guard-function');
 
 let capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
+
+// Silently fail when non-string is passed in
 capitalize = guard((str) => typeof str === 'string', capitalize);
 
 capitalize(12); // => undefined
@@ -26,8 +28,10 @@ capitalize("you shall not pass!"); // => "You shall not pass!"
 
 let div = (a, b) => a / b;
 
-div = guard((a, b) => b > 0, div, 0);
+// Throw exception instead of failing silently by passing an Error instance as 3rd param
+div = guard((a, b) => b > 0, div, new Error('Divide by 0!');
 
-div(8, 0); // => 0
 div(8, 2); // => 4
+
+div(8, 0); // => throws an Error
 ```

--- a/index.es6
+++ b/index.es6
@@ -5,8 +5,13 @@ let apply = (fn, args) => fn.apply(null, args);
 
 
 export default function(pred, fn, nothing) {
-  return (...args) => 
-    apply(pred, args)?
-    apply(fn, args):
-    nothing;
+  return (...args) =>  {
+    if (apply(pred, args))
+      return apply(fn, args);
+
+    if (nothing instanceof Error)
+      throw nothing;
+
+    return nothing;
+  };
 }

--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ module.exports = function (pred, fn, nothing) {
       args[_key] = arguments[_key];
     }
 
-    return apply(pred, args) ? apply(fn, args) : nothing;
+    if (apply(pred, args)) return apply(fn, args);
+
+    if (nothing instanceof Error) throw nothing;
+
+    return nothing;
   };
 };

--- a/test.es6
+++ b/test.es6
@@ -58,4 +58,15 @@ describe('guard', () => {
     expect(guard(F, spy, null)()).to.be(null);
     expect(spy.called).to.not.be.ok();
   });
+
+  it('should throw an Error if Error passed as nothing', () => {
+    spy = sinon.spy();
+    let err = new Error('ERROR');
+    try {
+      guard(F, spy, err);
+    } catch(e) {
+      expect(spy.called).to.not.be.ok();
+      expect(e).to.be(err);
+    }
+  });
 });

--- a/test.js
+++ b/test.js
@@ -73,4 +73,15 @@ describe("guard", function () {
     expect(guard(F, spy, null)()).to.be(null);
     expect(spy.called).to.not.be.ok();
   });
+
+  it("should throw an Error if Error passed as nothing", function () {
+    spy = sinon.spy();
+    var err = new Error("ERROR");
+    try {
+      guard(F, spy, err);
+    } catch (e) {
+      expect(spy.called).to.not.be.ok();
+      expect(e).to.be(err);
+    }
+  });
 });


### PR DESCRIPTION
I know that you can change the predicate to throw an exception instead of doing it this way, but it is useful in my case to support changing the guard reaction without changing the predicate.
